### PR TITLE
Add Additional testing on functionality of the Bandit tool [#1005]

### DIFF
--- a/tests/functional/test_baseline.py
+++ b/tests/functional/test_baseline.py
@@ -290,3 +290,30 @@ class BaselineFunctionalTests(testtools.TestCase):
     self.assertIn("subprocess.check_output(['ls'])", return_value)
     self.assertNotIn(baseline_no_issues_found, return_value)
     self.assertNotIn(baseline_no_skipped_files, return_value)
+
+def test_no_new_candidates(self):
+    """Tests when there are no new candidates
+    Test that bandit returns no issues found, as there are no new
+    candidates found compared with those found from the baseline.
+    """
+    baseline_report_files = {
+        "new_candidates-all.py": "new_candidates-all.py"
+    }
+    target_directory, baseline_code = self._create_baseline(
+        baseline_report_files
+    )
+    # assert the initial baseline found results
+    self.assertEqual(1, baseline_code)
+    baseline_report = os.path.join(
+        target_directory, self.baseline_report_file
+    )
+    return_value, return_code = self._run_bandit_baseline(
+        target_directory, baseline_report
+    )
+    # assert there were no results (no candidates found)
+    self.assertEqual(0, return_code)
+    self.assertIn(new_candidates_all_total_lines, return_value)
+    self.assertIn(new_candidates_skip_nosec_lines, return_value)
+    self.assertIn(baseline_no_skipped_files, return_value)
+    self.assertIn(baseline_no_issues_found, return_value)
+


### PR DESCRIPTION
**DESCRIPTION**
Here we added two additional assertions to verify that the output contains the strings "Files skipped (0):" and "No issues identified. These two strings indicate that no files were skipped during the scan and no issues were identified, respectively, which are expected when there are no new candidates found compared to the baseline

**SEVERITY**: Low

**Testing before implementation**
Test, when there are new candidates, found compared with those in the baseline. This should return the new candidate details along with the candidates from the baseline.

Test when a candidate has a # nosec comment added and that candidate was previously flagged as an issue in the baseline. This should not return that candidate in the results.

Test when a candidate has been fixed in the code and should no longer be flagged as an issue in the baseline. This should not return that candidate in the results. 